### PR TITLE
Workaround hyperref 7.01q natbib regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 /template.html
 /template.pdf
 /template.tex
+/template.aux
+/template.bbl
+/template.blg
+/template.log
+/template.out
 /jss.bst
 /jss.cls
 /jsslogo.jpg

--- a/_extensions/jss/_extension.yml
+++ b/_extensions/jss/_extension.yml
@@ -25,6 +25,14 @@ contributes:
 
           \newcommand{\class}[1]{`\code{#1}'}
           \newcommand{\fct}[1]{\code{#1()}}
+
+          % Workaround for hyperref 7.01q bug with natbib + cite in \maketitle abstract.
+          % Without this, citations inside \Abstract{} fail with "Undefined control sequence
+          % \@citeb" because \maketitle runs at \begin{document} (before natbib's loop sets
+          % \@citeb). Fix is in hyperref develop; see https://github.com/latex3/hyperref/issues/416
+          \makeatletter
+          \def\hyper@natlinkbreak#1#2{#1}
+          \makeatother
       fig-width: 4.9 # 6.125" * 0.8, as in template
       fig-height: 3.675 # 4.9 * 3:4
       template-partials:


### PR DESCRIPTION
Rendering the JSS template fails on TeX Live 2026 with:

```
Undefined control sequence.
<argument> cite.\@citeb
             \@extra@b@citeb
l.237 \begin{document}
```

## Root Cause

The recent hyperref update (`2026-04-24 v7.01q`) changed `\hyper@natlinkbreak` to call `\hyper@linkstart{cite}{cite.#2}`. natbib passes `{\@citeb\@extra@b@citeb}` as `#2` (literal CS tokens), and hyperref's `\find@pdflink` later runs `\protected@edef\Hy@testname{cite.\@citeb\@extra@b@citeb}` at a moment when `\@citeb` resolves as undefined.

This only surfaces in JSS because `jss.cls` auto-runs `\maketitle` at `\begin{document}`, and the abstract is typeset there with citations inside it.

The regression is tracked upstream at latex3/hyperref#416 and is already fixed on hyperref's `develop` branch; it has not yet shipped to CTAN.

## Fix

Apply the maintainer-recommended workaround by emptying `\hyper@natlinkbreak`'s body:

```latex
\makeatletter
\def\hyper@natlinkbreak#1#2{#1}
\makeatother
```

Citations render correctly. The hyperlink anchor on a per-citation line break is dropped, which is acceptable until upstream hyperref ships its fix to CTAN — at that point this can be reverted.

## Test Plan

- [x] `quarto render template.qmd --to jss-pdf` succeeds on TeX Live 2026 + Quarto 1.9.37
- [x] Same on an older TeX Live (no regression on systems with hyperref < 7.01q)

Related to #13
Related to latex3/hyperref#416
